### PR TITLE
Add version check on startup

### DIFF
--- a/Brewed.xcodeproj/project.pbxproj
+++ b/Brewed.xcodeproj/project.pbxproj
@@ -219,10 +219,10 @@
 			children = (
 				CD6C477925FCF34D004BA6DD /* Helpers */,
 				CD85838825FABE8E00E3974F /* ContentView.swift */,
-				CD6C476D25FCE0B0004BA6DD /* ServiceRow.swift */,
-				CD6C477025FCE2AC004BA6DD /* ServiceInfo.swift */,
 				CD525CD725FE359300785326 /* LogView.swift */,
+				CD6C477025FCE2AC004BA6DD /* ServiceInfo.swift */,
 				CD525CE425FE43C000785326 /* ServiceLogs.swift */,
+				CD6C476D25FCE0B0004BA6DD /* ServiceRow.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -231,13 +231,13 @@
 			isa = PBXGroup;
 			children = (
 				CDCCCE4925FBED2C00C3590A /* Collection.swift */,
+				CD525CDE25FE3DB900785326 /* DateFormatter.swift */,
 				CD6C478A25FD0B4F004BA6DD /* FileMonitor.swift */,
 				CD6C479425FD4721004BA6DD /* FolderMonitor.swift */,
 				CD525CCD25FE2E0300785326 /* Plist.swift */,
 				CDA7929025FBFBB3006FFAB1 /* Regex.swift */,
 				CDCCCE3E25FBE5E600C3590A /* Shell.swift */,
 				CDB92FDC25FD6531008FCFC9 /* TimeLogger.swift */,
-				CD525CDE25FE3DB900785326 /* DateFormatter.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";

--- a/Brewed.xcodeproj/project.pbxproj
+++ b/Brewed.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		CD6C478525FCF9E8004BA6DD /* RestartCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6C478425FCF9E8004BA6DD /* RestartCommand.swift */; };
 		CD6C478825FD0522004BA6DD /* GlobalAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6C478725FD0522004BA6DD /* GlobalAlert.swift */; };
 		CD6C478B25FD0B4F004BA6DD /* FileMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6C478A25FD0B4F004BA6DD /* FileMonitor.swift */; };
+		CD6C479925FD50B6004BA6DD /* HomebrewVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6C479825FD50B6004BA6DD /* HomebrewVersion.swift */; };
+		CD6C479C25FD5117004BA6DD /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6C479B25FD5117004BA6DD /* Version.swift */; };
 		CD85838725FABE8E00E3974F /* BrewedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD85838625FABE8E00E3974F /* BrewedApp.swift */; };
 		CD85838925FABE8E00E3974F /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD85838825FABE8E00E3974F /* ContentView.swift */; };
 		CD85838B25FABE9300E3974F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CD85838A25FABE9300E3974F /* Assets.xcassets */; };
@@ -38,6 +40,8 @@
 		CD6C478425FCF9E8004BA6DD /* RestartCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestartCommand.swift; sourceTree = "<group>"; };
 		CD6C478725FD0522004BA6DD /* GlobalAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalAlert.swift; sourceTree = "<group>"; };
 		CD6C478A25FD0B4F004BA6DD /* FileMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMonitor.swift; sourceTree = "<group>"; };
+		CD6C479825FD50B6004BA6DD /* HomebrewVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomebrewVersion.swift; sourceTree = "<group>"; };
+		CD6C479B25FD5117004BA6DD /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Version.swift; path = Brewed/Homebrew/Commands/Version.swift; sourceTree = SOURCE_ROOT; };
 		CD85838325FABE8E00E3974F /* Brewed.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Brewed.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD85838625FABE8E00E3974F /* BrewedApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrewedApp.swift; sourceTree = "<group>"; };
 		CD85838825FABE8E00E3974F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -70,6 +74,7 @@
 			isa = PBXGroup;
 			children = (
 				CD85839A25FABF1000E3974F /* ListCommand.swift */,
+				CD6C479B25FD5117004BA6DD /* Version.swift */,
 				CD6C477325FCEDFB004BA6DD /* RunCommand.swift */,
 				CD6C477E25FCF5E6004BA6DD /* StartCommand.swift */,
 				CD6C478425FCF9E8004BA6DD /* RestartCommand.swift */,
@@ -156,6 +161,7 @@
 			isa = PBXGroup;
 			children = (
 				CDCCCE4625FBE6D500C3590A /* Service.swift */,
+				CD6C479825FD50B6004BA6DD /* HomebrewVersion.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -275,8 +281,10 @@
 				CDA7929125FBFBB3006FFAB1 /* Regex.swift in Sources */,
 				CDCCCE4A25FBED2C00C3590A /* Collection.swift in Sources */,
 				CD6C478225FCF63E004BA6DD /* StopCommand.swift in Sources */,
+				CD6C479925FD50B6004BA6DD /* HomebrewVersion.swift in Sources */,
 				CDCCCE3F25FBE5E600C3590A /* Shell.swift in Sources */,
 				CD6C476E25FCE0B0004BA6DD /* ServiceRow.swift in Sources */,
+				CD6C479C25FD5117004BA6DD /* Version.swift in Sources */,
 				CD85839B25FABF1000E3974F /* ListCommand.swift in Sources */,
 				CD6C478B25FD0B4F004BA6DD /* FileMonitor.swift in Sources */,
 				CD6C477F25FCF5E6004BA6DD /* StartCommand.swift in Sources */,

--- a/Brewed/Homebrew/Commands/Version.swift
+++ b/Brewed/Homebrew/Commands/Version.swift
@@ -1,0 +1,33 @@
+//
+//  ListCommand.swift
+//  Brewed
+//
+//  Created by Rick Kerkhof on 11/03/2021.
+//
+
+import Foundation
+import PromiseKit
+
+struct VersionCommand: ShellCommandWrapper {
+    typealias resultType = HomebrewVersion
+    
+    let regex = try! NSRegularExpression(pattern: "\\S+")
+    
+    func exec() -> Promise<resultType> {
+        Promise { seal in
+            Shell.exec("/usr/local/bin/brew -v").done { _, output, _ in
+                var commands = output.split(whereSeparator: \.isNewline)
+                
+                let versionString = String(commands[0].split(separator: " ")[1])
+                var version = HomebrewVersion(version: versionString)
+                commands.remove(at: 0)
+                
+                commands.forEach { tap in
+                    version.taps.append(String(tap))
+                }
+            
+                seal.fulfill(version)
+            }.catch(seal.reject)
+        }
+    }
+}

--- a/Brewed/Homebrew/Model/HomebrewVersion.swift
+++ b/Brewed/Homebrew/Model/HomebrewVersion.swift
@@ -1,0 +1,14 @@
+//
+//  Version.swift
+//  Brewed
+//
+//  Created by Rick Kerkhof on 13/03/2021.
+//
+
+import Foundation
+
+struct HomebrewVersion {
+    let version: String
+    
+    var taps: [String] = []
+}

--- a/Brewed/View/ContentView.swift
+++ b/Brewed/View/ContentView.swift
@@ -20,9 +20,22 @@ struct ContentView: View {
     @State private var version = ""
 
     var body: some View {
-        List {
-            ForEach(managedServices.services) {
-                ServiceRow(service: $0).padding(.bottom)
+        VStack {
+            if managedServices.services.count <= 0 {
+                VStack {
+                    if managedServices.refreshing {
+                        Text("Refreshing...").font(.title)
+                    } else {
+                        Text("No services found").font(.title)
+                        Text("Check whether Homebrew is set up properly.")
+                    }
+                }.frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List {
+                    ForEach(managedServices.services) {
+                        ServiceRow(service: $0).padding(.bottom)
+                    }
+                }
             }
         }
         .onAppear(perform: {

--- a/Brewed/View/ContentView.swift
+++ b/Brewed/View/ContentView.swift
@@ -17,6 +17,8 @@ struct ContentView: View {
     @State private var bogus = false
     @State private var other = true
 
+    @State private var version = ""
+
     var body: some View {
         List {
             ForEach(managedServices.services) {
@@ -25,6 +27,16 @@ struct ContentView: View {
         }
         .onAppear(perform: {
             managedServices.refresh()
+
+            VersionCommand().exec().done { version in
+                self.version = version.version
+            }.catch { _ in
+                self.version = "N/A"
+                globalAlert.show(
+                    title: "Homebrew version check failed",
+                    body: "Could not gather Homebrew version information. Make sure it is installed properly."
+                )
+            }
         })
         .alert(isPresented: $globalAlert.shown) {
             Alert(
@@ -40,6 +52,7 @@ struct ContentView: View {
                 Image(systemName: "arrow.clockwise")
             }
         }
+        .navigationSubtitle("Homebrew \(version)")
         .environmentObject(managedServices)
         .environmentObject(globalAlert)
     }

--- a/Brewed/View/ContentView.swift
+++ b/Brewed/View/ContentView.swift
@@ -26,10 +26,9 @@ struct ContentView: View {
             }
         }
         .onAppear(perform: {
-            managedServices.refresh()
-
             VersionCommand().exec().done { version in
                 self.version = version.version
+                managedServices.refresh()
             }.catch { _ in
                 self.version = "N/A"
                 globalAlert.show(


### PR DESCRIPTION
This checks if Homebrew is installed properly and extracts version information.

Possibly expand on this and only run the initial refresh once version check is complete and determined working?