### PR TITLE
Parse log file locations from plist files

### DIFF
--- a/Brewed.xcodeproj/project.pbxproj
+++ b/Brewed.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		CDA7928725FBEFC9006FFAB1 /* ManagedServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA7928625FBEFC9006FFAB1 /* ManagedServices.swift */; };
 		CDA7928D25FBFA58006FFAB1 /* AutostartService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA7928C25FBFA58006FFAB1 /* AutostartService.swift */; };
 		CDA7929125FBFBB3006FFAB1 /* Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA7929025FBFBB3006FFAB1 /* Regex.swift */; };
+		CDB9291C2609061F00CAB3AA /* LaunchdPlistRepresentative.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB9291B2609061F00CAB3AA /* LaunchdPlistRepresentative.swift */; };
 		CDB92FDD25FD6531008FCFC9 /* TimeLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB92FDC25FD6531008FCFC9 /* TimeLogger.swift */; };
 		CDCCCE3F25FBE5E600C3590A /* Shell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCCCE3E25FBE5E600C3590A /* Shell.swift */; };
 		CDCCCE4425FBE6A400C3590A /* PromiseKit in Frameworks */ = {isa = PBXBuildFile; productRef = CDCCCE4325FBE6A400C3590A /* PromiseKit */; };
@@ -72,6 +73,7 @@
 		CDA7928625FBEFC9006FFAB1 /* ManagedServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedServices.swift; sourceTree = "<group>"; };
 		CDA7928C25FBFA58006FFAB1 /* AutostartService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutostartService.swift; sourceTree = "<group>"; };
 		CDA7929025FBFBB3006FFAB1 /* Regex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Regex.swift; sourceTree = "<group>"; };
+		CDB9291B2609061F00CAB3AA /* LaunchdPlistRepresentative.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchdPlistRepresentative.swift; sourceTree = "<group>"; };
 		CDB92FDC25FD6531008FCFC9 /* TimeLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeLogger.swift; sourceTree = "<group>"; };
 		CDCCCE3E25FBE5E600C3590A /* Shell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shell.swift; sourceTree = "<group>"; };
 		CDCCCE4625FBE6D500C3590A /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 			children = (
 				CD525CDA25FE37BA00785326 /* Log.swift */,
 				CDA7928625FBEFC9006FFAB1 /* ManagedServices.swift */,
+				CDB9291B2609061F00CAB3AA /* LaunchdPlistRepresentative.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -346,6 +349,7 @@
 				CD6C477F25FCF5E6004BA6DD /* StartCommand.swift in Sources */,
 				CD6C478825FD0522004BA6DD /* GlobalAlert.swift in Sources */,
 				CD6C477425FCEDFB004BA6DD /* RunCommand.swift in Sources */,
+				CDB9291C2609061F00CAB3AA /* LaunchdPlistRepresentative.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Brewed/Helpers/Plist.swift
+++ b/Brewed/Helpers/Plist.swift
@@ -22,4 +22,14 @@ struct Plist {
 
         return dict
     }
+
+    static func path(for service: String) -> String? {
+        let path = "/usr/local/opt/\(service)/homebrew.mxcl.\(service).plist"
+        
+        if FileManager.default.fileExists(atPath: path) {
+            return path
+        }
+
+        return nil
+    }
 }

--- a/Brewed/Helpers/Plist.swift
+++ b/Brewed/Helpers/Plist.swift
@@ -23,6 +23,15 @@ struct Plist {
         return dict
     }
 
+    static func deserialize<T: Decodable>(url: URL) throws -> T {
+        let infoPlistData = try Data(contentsOf: url)
+
+        return try PropertyListDecoder().decode(
+            T.self,
+            from: infoPlistData
+        )
+    }
+
     static func path(for service: String) -> String? {
         let path = "/usr/local/opt/\(service)/homebrew.mxcl.\(service).plist"
         
@@ -31,5 +40,15 @@ struct Plist {
         }
 
         return nil
+    }
+}
+
+extension Service {
+    func deserializePlist() -> LaunchdPlistRepresentative? {
+        guard let plist = self.plist else {
+            return nil
+        }
+
+        return try? Plist.deserialize(url: plist)
     }
 }

--- a/Brewed/Helpers/Plist.swift
+++ b/Brewed/Helpers/Plist.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct Plist {
-    static func deserialise<K: Hashable, V: Any>(url: URL) throws -> [K: V]? {
+    static func toMap<K: Hashable, V: Any>(url: URL) throws -> [K: V]? {
         let infoPlistData = try Data(contentsOf: url)
 
         guard let dict = try PropertyListSerialization.propertyList(

--- a/Brewed/Homebrew/Commands/Services/ListCommand.swift
+++ b/Brewed/Homebrew/Commands/Services/ListCommand.swift
@@ -27,7 +27,7 @@ struct ListServicesCommand: ShellCommandWrapper {
                     let name = parts[0]
                     let status = parts[1]
                     let user = parts[safe: 2]
-                    let plist = parts[safe: 3]
+                    let plist = parts[safe: 3] ?? Plist.path(for: name)
 
                     result.append(Service(
                         id: name,

--- a/Brewed/Model/LaunchdPlistRepresentative.swift
+++ b/Brewed/Model/LaunchdPlistRepresentative.swift
@@ -1,0 +1,19 @@
+//
+//  LaunchdPlistRepresentative.swift
+//  Brewed
+//
+//  Created by Rick Kerkhof on 22/03/2021.
+//
+
+import Foundation
+
+struct LaunchdPlistRepresentative: Codable {
+    let Label: String
+    
+    let ProgramArguments: [String]
+    
+    let WorkingDirectory: String
+    
+    let StandardErrorPath: String?
+    let StandardOutputPath: String?
+}

--- a/Brewed/Resources/LogMappings.plist
+++ b/Brewed/Resources/LogMappings.plist
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>php</key>
-	<array>
-		<string>/usr/local/var/log/php-fpm.log</string>
-	</array>
-</dict>
+<dict/>
 </plist>

--- a/Brewed/Resources/LogMappings.plist
+++ b/Brewed/Resources/LogMappings.plist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>mongodb-community</key>
+	<array>
+		<string>/usr/local/var/log/mongodb/mongo.log</string>
+	</array>
+</dict>
 </plist>

--- a/Brewed/Services/LogsService.swift
+++ b/Brewed/Services/LogsService.swift
@@ -48,7 +48,22 @@ struct LogsService {
 
 extension Service {
     func logPaths() -> [URL]? {
-        LogsService.shared.paths(for: id)
+        var servicePaths = LogsService.shared.paths(for: id) ?? []
+        
+        if let launchd = self.deserializePlist() {
+            if let stderr = launchd.StandardErrorPath {
+                servicePaths.append(URL(fileURLWithPath: stderr))
+            }
+            if let stdout = launchd.StandardOutputPath, stdout != launchd.StandardErrorPath {
+                servicePaths.append(URL(fileURLWithPath: stdout))
+            }
+        }
+        
+        guard servicePaths.count > 0 else {
+            return nil
+        }
+        
+        return servicePaths
     }
 }
 

--- a/Brewed/Services/LogsService.swift
+++ b/Brewed/Services/LogsService.swift
@@ -18,7 +18,7 @@ struct LogsService {
 
     init() {
         guard let mappingsPath = Bundle.main.url(forResource: "LogMappings", withExtension: "plist"),
-              let plistContents: [String: [String]] = try? Plist.deserialise(url: mappingsPath)
+              let plistContents: [String: [String]] = try? Plist.toMap(url: mappingsPath)
         else {
             logger.warning("Could not read mappings Plist; proceeding without mappings. No logs will be available.")
             logPaths = [:]


### PR DESCRIPTION
This allows for automatic detection of loads of paths for services by leveraging StandardErrorPath and StandardOutputPath from their plist files.

On top of this, this PR adds detection of standard plist locations even when services are idle.